### PR TITLE
feat(settings): add persistent settings and improve UI with scrollbars

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,16 +6,17 @@ import SessionStats from './components/SessionStats';
 import Footer from './components/Footer';
 import { sampleTexts } from './data/sampleTexts';
 import { audioManager } from './utils/audioManager';
+import { settingsStorage } from './utils/settingsStorage';
 
 function App() {
   const [selectedText, setSelectedText] = useState(sampleTexts[0].text);
-  const [showIPA, setShowIPA] = useState(false);
-  const [soundEnabled, setSoundEnabled] = useState(true);
-  const [showHistory, setShowHistory] = useState(true); // Show history by default
-  const [dictationMode, setDictationMode] = useState(false);
-  const [theme, setTheme] = useState('normal'); // 'normal' or 'geek'
+  const [showIPA, setShowIPA] = useState(() => settingsStorage.get('showIPA'));
+  const [soundEnabled, setSoundEnabled] = useState(() => settingsStorage.get('soundEnabled'));
+  const [showHistory, setShowHistory] = useState(() => settingsStorage.get('showHistory'));
+  const [dictationMode, setDictationMode] = useState(() => settingsStorage.get('dictationMode'));
+  const [theme, setTheme] = useState(() => settingsStorage.get('theme'));
   const [completedSessions, setCompletedSessions] = useState([]);
-  const [activeSection, setActiveSection] = useState('practice'); // 'practice' or 'templates'
+  const [activeSection, setActiveSection] = useState(() => settingsStorage.get('activeSection'));
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -57,6 +58,32 @@ function App() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [soundEnabled]);
 
+  // Persist settings when they change
+  useEffect(() => {
+    settingsStorage.set('theme', theme);
+  }, [theme]);
+
+  useEffect(() => {
+    settingsStorage.set('showIPA', showIPA);
+  }, [showIPA]);
+
+  useEffect(() => {
+    settingsStorage.set('soundEnabled', soundEnabled);
+    audioManager.setEnabled(soundEnabled);
+  }, [soundEnabled]);
+
+  useEffect(() => {
+    settingsStorage.set('dictationMode', dictationMode);
+  }, [dictationMode]);
+
+  useEffect(() => {
+    settingsStorage.set('showHistory', showHistory);
+  }, [showHistory]);
+
+  useEffect(() => {
+    settingsStorage.set('activeSection', activeSection);
+  }, [activeSection]);
+
   const handleTextSelect = (text) => {
     setSelectedText(text);
   };
@@ -73,7 +100,6 @@ function App() {
   const toggleSound = () => {
     const newSoundEnabled = !soundEnabled;
     setSoundEnabled(newSoundEnabled);
-    audioManager.setEnabled(newSoundEnabled);
   };
 
   return (

--- a/src/components/TextInput.jsx
+++ b/src/components/TextInput.jsx
@@ -50,12 +50,12 @@ const TextInput = ({ onTextSubmit, theme = 'normal' }) => {
                 ? '// paste.your.english.text.here...' 
                 : 'Paste or type your English paragraph here...'
               }
-              className={`w-full h-32 p-3 border focus:outline-none focus:ring-2 ${
+              className={`w-full h-48 p-3 border focus:outline-none focus:ring-2 resize-none overflow-y-auto ${
                 theme === 'geek'
-                  ? 'border-green-500/30 bg-black text-green-400 font-mono focus:ring-green-400 focus:border-green-400 placeholder-green-400/40'
-                  : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md focus:ring-blue-500'
+                  ? 'border-green-500/30 bg-black text-green-400 font-mono focus:ring-green-400 focus:border-green-400 placeholder-green-400/40 custom-scrollbar-geek'
+                  : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md focus:ring-blue-500 custom-scrollbar'
               }`}
-              maxLength={5000}
+              maxLength={25000}
               autoFocus
             />
             <div className="flex justify-between items-center mt-4">
@@ -64,10 +64,12 @@ const TextInput = ({ onTextSubmit, theme = 'normal' }) => {
                   ? 'text-green-400/60 font-mono'
                   : 'text-gray-500'
               }`}>
-                {theme === 'geek' 
-                  ? `// chars: ${text.length}/5000` 
-                  : `${text.length}/5000 characters`
-                }
+                {(() => {
+                  const wordCount = text.trim().split(/\s+/).filter(word => word.length > 0).length;
+                  return theme === 'geek' 
+                    ? `// chars: ${text.length.toLocaleString()}/25K | words: ${wordCount.toLocaleString()}/5K` 
+                    : `${text.length.toLocaleString()}/25,000 characters (${wordCount.toLocaleString()} words)`;
+                })()}
               </span>
               <div className="space-x-2">
                 <button

--- a/src/components/TypingArea.jsx
+++ b/src/components/TypingArea.jsx
@@ -12,10 +12,21 @@ const TypingArea = ({ text, onComplete, showIPA = false, dictationMode = false, 
   const [wordErrors, setWordErrors] = useState({});
   const [stats, setStats] = useState(null);
   const inputRef = useRef(null);
+  const scrollContainerRef = useRef(null);
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  // Auto-scroll to keep current word visible
+  useEffect(() => {
+    if (scrollContainerRef.current && currentWordIndex > 0) {
+      const currentWordElement = scrollContainerRef.current.querySelector(`[data-word-index="${currentWordIndex}"]`);
+      if (currentWordElement) {
+        currentWordElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+  }, [currentWordIndex]);
 
   const handleKeyDown = (e) => {
     e.preventDefault();
@@ -316,25 +327,33 @@ const TypingArea = ({ text, onComplete, showIPA = false, dictationMode = false, 
             </div>
           ) : (
             <>
-              <div className={`flex flex-wrap leading-relaxed items-start ${
-                theme === 'geek' ? 'font-mono' : 'font-mono'
-              }`}>
-                {words.map((word, wordIndex) => (
-                  <WordDisplay
-                    key={wordIndex}
-                    word={word}
-                    ipa={getIPA(word)}
-                    currentCharIndex={wordIndex === currentWordIndex ? currentCharIndex : 0}
-                    isCurrentWord={wordIndex === currentWordIndex}
-                    isCompleted={wordIndex < currentWordIndex}
-                    typedChars={wordTypedChars[wordIndex] || ''}
-                    errors={wordErrors[wordIndex] || []}
-                    showIPA={showIPA}
-                    dictationMode={dictationMode}
-                    theme={theme}
-                    showSpace={wordIndex < words.length - 1} // Show space for all words except the last
-                  />
-                ))}
+              <div 
+                ref={scrollContainerRef}
+                className={`max-h-96 overflow-y-auto px-1 ${
+                  theme === 'geek' ? 'custom-scrollbar-geek' : 'custom-scrollbar'
+                }`}
+              >
+                <div className={`flex flex-wrap leading-relaxed items-start ${
+                  theme === 'geek' ? 'font-mono' : 'font-mono'
+                }`}>
+                  {words.map((word, wordIndex) => (
+                    <div key={wordIndex} data-word-index={wordIndex}>
+                      <WordDisplay
+                        word={word}
+                        ipa={getIPA(word)}
+                        currentCharIndex={wordIndex === currentWordIndex ? currentCharIndex : 0}
+                        isCurrentWord={wordIndex === currentWordIndex}
+                        isCompleted={wordIndex < currentWordIndex}
+                        typedChars={wordTypedChars[wordIndex] || ''}
+                        errors={wordErrors[wordIndex] || []}
+                        showIPA={showIPA}
+                        dictationMode={dictationMode}
+                        theme={theme}
+                        showSpace={wordIndex < words.length - 1} // Show space for all words except the last
+                      />
+                    </div>
+                  ))}
+                </div>
               </div>
               
             </>

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,33 @@
 }
 
 @layer utilities {
+  /* Custom scrollbar styles */
+  .custom-scrollbar {
+    scrollbar-width: thin;
+  }
+  
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  
+  .custom-scrollbar::-webkit-scrollbar-track {
+    @apply bg-gray-100 dark:bg-gray-800 rounded;
+  }
+  
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    @apply bg-gray-400 dark:bg-gray-600 rounded hover:bg-gray-500 dark:hover:bg-gray-500;
+  }
+  
+  /* Geek theme scrollbar */
+  .custom-scrollbar-geek::-webkit-scrollbar-track {
+    @apply bg-green-900/20 rounded;
+  }
+  
+  .custom-scrollbar-geek::-webkit-scrollbar-thumb {
+    @apply bg-green-500/50 rounded hover:bg-green-400/70;
+  }
+  
   /* Smooth animations */
   .animate-slide-up {
     animation: slideUp 0.3s ease-out;

--- a/src/utils/customTextStorage.js
+++ b/src/utils/customTextStorage.js
@@ -1,5 +1,7 @@
 const STORAGE_KEY = 'zen-typing-custom-texts';
 const MAX_HISTORY_ITEMS = 50;
+const MAX_TEXT_LENGTH = 25000; // 5K words ~ 25K characters
+const STORAGE_SIZE_LIMIT = 5 * 1024 * 1024; // 5MB localStorage limit
 
 export const customTextStorage = {
   // Get all custom texts from localStorage
@@ -17,17 +19,26 @@ export const customTextStorage = {
   add(text) {
     if (!text || text.trim().length === 0) return;
     
+    const trimmedText = text.trim();
+    
+    // Check text length
+    if (trimmedText.length > MAX_TEXT_LENGTH) {
+      console.warn(`Text exceeds maximum length of ${MAX_TEXT_LENGTH} characters`);
+      return null;
+    }
+    
     const texts = this.getAll();
     
     // Remove duplicate if exists
-    const filtered = texts.filter(item => item.text !== text.trim());
+    const filtered = texts.filter(item => item.text !== trimmedText);
     
     // Add new text at the beginning
     const newItem = {
       id: Date.now().toString(),
-      text: text.trim(),
+      text: trimmedText,
       timestamp: Date.now(),
-      wordCount: text.trim().split(/\s+/).length
+      wordCount: trimmedText.split(/\s+/).filter(word => word.length > 0).length,
+      charCount: trimmedText.length
     };
     
     const updated = [newItem, ...filtered];
@@ -35,11 +46,31 @@ export const customTextStorage = {
     // Keep only the most recent items
     const trimmed = updated.slice(0, MAX_HISTORY_ITEMS);
     
+    // Check storage size before saving
     try {
+      const dataSize = new Blob([JSON.stringify(trimmed)]).size;
+      if (dataSize > STORAGE_SIZE_LIMIT) {
+        // Remove oldest items until size is acceptable
+        while (trimmed.length > 1 && new Blob([JSON.stringify(trimmed)]).size > STORAGE_SIZE_LIMIT) {
+          trimmed.pop();
+        }
+      }
+      
       localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
       return newItem;
     } catch (error) {
       console.error('Failed to save custom text:', error);
+      // If quota exceeded, try to save with fewer items
+      if (error.name === 'QuotaExceededError') {
+        const reduced = trimmed.slice(0, Math.floor(trimmed.length / 2));
+        try {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(reduced));
+          return newItem;
+        } catch (secondError) {
+          console.error('Failed to save even with reduced history:', secondError);
+          return null;
+        }
+      }
       return null;
     }
   },

--- a/src/utils/settingsStorage.js
+++ b/src/utils/settingsStorage.js
@@ -1,0 +1,82 @@
+const SETTINGS_KEY = 'zen-typing-settings';
+
+// Default settings
+const DEFAULT_SETTINGS = {
+  theme: 'normal', // 'normal' or 'geek'
+  ipaDisplay: 'toggle', // 'toggle', 'hover', 'click', 'always' - future feature
+  showIPA: false,
+  dictationMode: false,
+  showHistory: true,
+  fontSize: 'medium', // 'small', 'medium', 'large'
+  soundEnabled: true,
+  showProgress: true,
+  showTimer: true,
+  keyboardLayout: 'qwerty',
+  activeSection: 'practice' // 'practice' or 'templates'
+};
+
+export const settingsStorage = {
+  // Get all settings or a specific setting
+  get(key = null) {
+    try {
+      const stored = localStorage.getItem(SETTINGS_KEY);
+      const settings = stored ? JSON.parse(stored) : DEFAULT_SETTINGS;
+      
+      // Merge with defaults to ensure all keys exist
+      const merged = { ...DEFAULT_SETTINGS, ...settings };
+      
+      if (key) {
+        return merged[key] !== undefined ? merged[key] : DEFAULT_SETTINGS[key];
+      }
+      
+      return merged;
+    } catch (error) {
+      console.error('Failed to load settings:', error);
+      return key ? DEFAULT_SETTINGS[key] : DEFAULT_SETTINGS;
+    }
+  },
+
+  // Set a specific setting or multiple settings
+  set(keyOrSettings, value = undefined) {
+    try {
+      const currentSettings = this.get();
+      let newSettings;
+      
+      if (typeof keyOrSettings === 'object') {
+        // Setting multiple values
+        newSettings = { ...currentSettings, ...keyOrSettings };
+      } else {
+        // Setting single value
+        newSettings = { ...currentSettings, [keyOrSettings]: value };
+      }
+      
+      localStorage.setItem(SETTINGS_KEY, JSON.stringify(newSettings));
+      return true;
+    } catch (error) {
+      console.error('Failed to save settings:', error);
+      return false;
+    }
+  },
+
+  // Reset to default settings
+  reset() {
+    try {
+      localStorage.setItem(SETTINGS_KEY, JSON.stringify(DEFAULT_SETTINGS));
+      return true;
+    } catch (error) {
+      console.error('Failed to reset settings:', error);
+      return false;
+    }
+  },
+
+  // Clear all settings
+  clear() {
+    try {
+      localStorage.removeItem(SETTINGS_KEY);
+      return true;
+    } catch (error) {
+      console.error('Failed to clear settings:', error);
+      return false;
+    }
+  }
+};


### PR DESCRIPTION
- Add settingsStorage utility for persisting all user preferences
- Persist theme, IPA display, sound, dictation, history, and section preferences
- Change input limit from 5K to 25K characters (5K words)
- Add word count display to text input area
- Add custom scrollbars to both text input and typing areas
- Implement theme-aware scrollbar styling (normal and geek themes)
- Add auto-scroll to keep current word visible during typing
- Improve storage management with proper error handling and quota limits